### PR TITLE
Fix documentation link paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ address your problems!
 
 This project has adopted the [Microsoft Open Source Code of
 Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the
-[CODE_OF_CONDUCT.md](./docs/CODE_OF_CONDUCT.md) file.
+[CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) file.
 
 ## Transparency FAQ
 
 For more information about how the Azure Resource Manager MCP server AI capabilities works, its
 limitations, and best practices for use, please refer to our [Transparency
-FAQ](./docs/TransparencyFAQ.md).
+FAQ](./ResponsibleAITransparencyFAQ.md).
 
 ## License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -87,4 +87,4 @@ permissions to query or deploy a resource, the server will deny the operation.
 
 You can explicitly block any deployment from the Azure Resource Manager MCP server by applying an Azure
 Policy that denies deployments from that service, see the [README
-Governance](./README.md#governance) for more details.
+Governance](../README.md#governance) for more details.


### PR DESCRIPTION
## Summary
- Fix README links to Code of Conduct and Transparency FAQ
- Fix FAQ link to README governance section

## Testing
- Not applicable (doc-only change)